### PR TITLE
Quote variables to prevent globbing and splitting

### DIFF
--- a/notebook/notebook.sh
+++ b/notebook/notebook.sh
@@ -2,11 +2,11 @@
 
 # Strict mode
 set -euo pipefail
-IFS=$'\n\t' 
+IFS=$'\n\t'
 
 # Create a self signed certificate for the user if one doesn't exist
-if [ ! -f $PEM_FILE ]; then
-  openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout $PEM_FILE -out $PEM_FILE \
+if [ ! -f "$PEM_FILE" ]; then
+  openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout "$PEM_FILE" -out "$PEM_FILE" \
     -subj "/C=XX/ST=XX/L=XX/O=dockergenerated/CN=dockergenerated"
 fi
 
@@ -17,7 +17,7 @@ unset PASSWORD
 
 CERTFILE_OPTION="--certfile=$PEM_FILE"
 
-if [ $USE_HTTP -ne 0 ]; then
+if [ "$USE_HTTP" -ne 0 ]; then
   CERTFILE_OPTION=""
 fi
 


### PR DESCRIPTION
This allows the path to `$PEM_FILE` to include spaces.